### PR TITLE
Add CLI parsing with mow cli

### DIFF
--- a/cmd/linkwarp/main.go
+++ b/cmd/linkwarp/main.go
@@ -2,47 +2,135 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/warpfork/linkwarp"
+
+	"github.com/jawher/mow.cli"
 )
 
+type ExitCode int
+
+const (
+	ExitCodeOkay ExitCode = iota
+	ExitCodeUnknownError
+	ExitCodePanic
+	ExitCodeError    ExitCode = 25
+	ExitCodeMetanoia ExitCode = 26
+	ExitCodeUsage    ExitCode = 27
+)
+
+// Go up three, because we want to exit "bin/", exit (presumably) "linkwarp*/", exit (presumably) "apps/", and then enter "apps/" and "bin/" again explicitly from there.
+// This results in linkwarp DTRT'ing if installed in the canonical sort of location warpsys conventions would have you put it in, and in all links still being relative.
+const (
+	DefaultAppsPath = "../../../apps/"
+	DefaultBinPath  = "../../../bin/"
+)
+
+// 1 arg form: linkwarp
+// 2 arg form: linkwarp [root]
+// 3 arg form: linkewarp [search root] [bin root]
 func main() {
-	var searchRoot, binRoot string
-	switch len(os.Args) {
-	case 1:
+	ctx := &ActionContext{
+		Context: context.Background(),
+	}
+	app := cli.App("linkwarp", "does things!\nWith no arguments will start at the path of the linkwarp executable")
+	app.Spec = "[-v] ( [ROOT] | ( SEARCHROOT BINROOT ) )"
+
+	app.BoolOptPtr(&ctx.Config.Verbose, "v verbose", false, "Enable logging output on stderr")
+	app.StringArgPtr(&ctx.Config.Root, "ROOT", "", "Single argument replaces both SEARCHROOT and BINROOT")
+	app.StringPtr(&ctx.Config.Search.SearchRoot, cli.StringArg{
+		Name:      "SEARCHROOT",
+		Value:     DefaultAppsPath,
+		Desc:      "the path to search for binaries",
+		SetByUser: &ctx.Config.SearchSetByUser,
+	})
+	app.StringArgPtr(&ctx.Config.Synthesis.BinRoot, "BINROOT", DefaultBinPath, "the path to place links")
+	app.Before = Action(ctx, logConfig)
+	app.Action = Action(ctx, run)
+	app.After = Action(ctx, exitHandler)
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Println(err)
+		os.Exit(int(ExitCodeUsage))
+	}
+	os.Exit(int(ExitCodeOkay))
+}
+
+type Config struct {
+	Root            string
+	SearchSetByUser bool
+	Search          linkwarp.BinSearchCfg
+	Synthesis       linkwarp.BinSynthesisCfg
+	Verbose         bool
+}
+
+type ActionContext struct {
+	context.Context
+	Config
+	Error error
+}
+
+type ActionFunc func(*ActionContext) error
+
+func Action(c *ActionContext, funcs ...ActionFunc) func() {
+	if c.Context == nil {
+		c.Context = context.Background()
+	}
+	if c.Error != nil {
+		return func() {}
+	}
+	return func() {
+		for _, f := range funcs {
+			err := f(c)
+			if err != nil {
+				c.Error = err
+				break
+			}
+		}
+	}
+}
+
+func logConfig(c *ActionContext) error {
+	if c.Config.Verbose {
+		log.SetFlags(0)
+		return nil
+	}
+	log.SetOutput(io.Discard)
+	return nil
+}
+
+func run(c *ActionContext) error {
+	ctx := c.Context
+	if c.Config.Root == "" && !c.Config.SearchSetByUser {
+		log.Println("Args: 0")
 		self, err := os.Executable()
 		if err != nil {
-			fmt.Printf("linkwarp: cannot find self: %s\n", err)
-			os.Exit(26)
+			log.Printf("linkwarp: cannot find self: %s\n", err)
+			os.Exit(int(ExitCodeMetanoia)) // TODO: proper error handling and not exiting in the middle of an action
 		}
 		os.Chdir(filepath.Dir(self))
-		// Go up three, because we want to exit "bin/", exit (presumably) "linkwarp*/", exit (presumably) "apps/", and then enter "apps/" and "bin/" again explicitly from there.
-		// This results in linkwarp DTRT'ing if installed in the canonical sort of location warpsys conventions would have you put it in, and in all links still being relative.
-		searchRoot = "../../../apps/"
-		binRoot = "../../../bin/"
-	case 2:
-		searchRoot = filepath.Join(os.Args[1], "apps")
-		binRoot = filepath.Join(os.Args[1], "bin")
-	case 3:
-		searchRoot = os.Args[1]
-		binRoot = os.Args[2]
-	default:
-		fmt.Printf("linkwarp: incorrect usage, acceptable usage is 0, 1, or 2 args\n")
-		os.Exit(27)
+		c.Config.Search.SearchRoot = DefaultAppsPath
+		c.Config.Synthesis.BinRoot = DefaultBinPath
 	}
+	if c.Config.Root != "" {
+		log.Println("Args: 1")
+		c.Config.Search.SearchRoot = c.Config.Root
+		c.Config.Synthesis.BinRoot = c.Config.Root
+	}
+	c.Config.Synthesis.AppRoot = c.Config.Search.SearchRoot
+	log.Printf(`{"approot": %q, "binroot": %q}`, c.Config.Synthesis.AppRoot, c.Config.Synthesis.BinRoot)
+	return c.Config.Search.StartSearch(ctx, c.Config.Synthesis.UpdateLinks)
+}
 
-	searchCfg := linkwarp.BinSearchCfg{
-		SearchRoot: searchRoot,
+func exitHandler(c *ActionContext) error {
+	if c.Error != nil {
+		log.Println(c.Error)
+		os.Exit(int(ExitCodeError))
 	}
-	synthCfg := linkwarp.BinSynthesisCfg{
-		BinRoot: binRoot,
-		AppRoot: searchCfg.SearchRoot,
-	}
-	if err := searchCfg.StartSearch(context.Background(), synthCfg.UpdateLinks); err != nil {
-		fmt.Printf("linkwarp: error: %s\n", err)
-		os.Exit(25)
-	}
+	os.Exit(int(ExitCodeOkay))
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/warpfork/linkwarp
 
 go 1.18
 
-require facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb // indirect
+require (
+	facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb // indirect
+	github.com/jawher/mow.cli v1.2.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,14 @@
 facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb h1:1pSweJFeR3Pqx7uoelppkzeegfUBXL6I2FFAbfXw570=
 facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:npRYmtaITVom7rcSo+pRURltHSG2r4TQM1cdqJ2dUB0=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jawher/mow.cli v1.2.0 h1:e6ViPPy+82A/NFF/cfbq3Lr6q4JHKT9tyHwTCcUQgQw=
+github.com/jawher/mow.cli v1.2.0/go.mod h1:y+pcA3jBAdo/GIZx/0rFjw/K2bVEODP9rfZOfaiq8Ko=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
In all it's hacky glory, precisely (plus `-v` for debugging with `log`) implements the existing CLI with mow. I'm honestly kind of impressed that it's even doable and that I managed to do it without global variables.